### PR TITLE
fix bug in getbrho  and getbrhoinv due to energy

### DIFF
--- a/mml/getbrho.m
+++ b/mml/getbrho.m
@@ -22,6 +22,7 @@ function brho = getbrho(varargin)
 
 %  Written by James Safranek, Moohyun Yoon, Greg Portmann
 %  Modified by Laurent S. Nadolski (09/02/06 exact computation using kinetic energy correction)
+%  2024apr30 oblanco, use total energy from AT. https://github.com/atcollab/at/discussions/671
 
 
 Energy = [];
@@ -50,30 +51,7 @@ if isempty(Energy)
     Energy = getenergy;
 end
 
+lightspeed = PhysConstant.speed_of_light_in_vacuum.value;
+emassGeV = PhysConstant.electron_mass_energy_equivalent_in_MeV.value*1e-3;
 % Exact formula is mandatory for low energy like in transfer lines
-E0 = .51099906e-3;    % Electron rest mass in GeV
-%brho = (10/2.99792458) * sqrt(Energy.^2 - E0.^2);
-% WARNING AT and other tracking code give kinetic energy and not total energy
-brho = (10/2.99792458) * sqrt((Energy+E0).^2 - E0.^2);
-
-
-% if nargin == 0
-% %     warning('1 input not given (beam energy in GeV): to');    
-%     E = getenergy;    
-% else
-%     E = energy;
-% end
-% 
-% m0 = 9.1093897e-31 ;
-% e    = 1.60217733e-19 ;
-% c    = 2.99792458e+8 ;
-% 
-% % t1   = energy*1e9*e;
-% % v    = c*sqrt(t1*(2*m0*c*c+t1)/((m0*c*c+t1)^2));
-% % gamma= 1./sqrt(1.-v*v/c/c);
-% % p    = m0*c*sqrt(gamma*gamma-1.);
-% % brho = p/e;
-% E = E*1e9*e;
-% E0 = m0*c*c;
-% 
-% brho = sqrt(E*E - E0*E0)/c/e; 
+brho = (1e9/lightspeed) * sqrt(Energy.^2 - emassGeV.^2);

--- a/mml/getbrhoinv.m
+++ b/mml/getbrhoinv.m
@@ -12,15 +12,12 @@ function e = getbrhoinv(brho)
 
 %  Written by James Safranek, Moohyun Yoon, Greg Portmann
 %  Modified by Laurent S. Nadolski (09/02/06 exact computation using kinetic energy correction)
-
+%  2024apr30 oblanco, use total energy from AT. https://github.com/atcollab/at/discussions/671
 
 if nargin == 0
     error('Brho input needed.');
 end
 
-E0 = .51099906e-3;    % Electron rest mass in GeV
-% WARNING AT and other tracking code give kinetic energy and not total energy
-e = sqrt(E0^2 + (.299792458 * brho).^2) - E0;        % Laurants total energy
-%e = sqrt(E0^2 + (.299792458 * brho).^2);            % Old code
-
-
+emassGeV = PhysConstant.electron_mass_energy_equivalent_in_MeV.value*1e-3;
+lightspeed = PhysConstant.speed_of_light_in_vacuum.value;
+e = sqrt(emassGeV.^2 + (brho * lightspeed*1e-9).^2);


### PR DESCRIPTION
This PR changes the formula to calculate $B\rho$ in getbrho.m and getbhroinv.m following the issue #6  and the response to the discussion on AT https://github.com/atcollab/at/discussions/671 .

